### PR TITLE
fix(mn): cover page title handling and toDOM array format

### DIFF
--- a/packages/anafero-gui/App.tsx
+++ b/packages/anafero-gui/App.tsx
@@ -62,7 +62,7 @@ export const AppLoader: React.FC<{ onDone: () => void }> = function ({ onDone })
     ? ((slashPrependedPath: string) => slashPrependedPath)
     : ((slashPrependedPath: string) => {
         const unprefixed = slashPrependedPath.startsWith(pathPrefix)
-          ? slashPrependedPath.replace(pathPrefix, '')
+          ? slashPrependedPath.replace(pathPrefix, '') || '/'
           : slashPrependedPath;
         if (!unprefixed.startsWith('/')) {
           console.error("Non-slash-prepended path after getSiteRootRelativePath!", unprefixed, slashPrependedPath);

--- a/packages/metanorma-site-content/index.mts
+++ b/packages/metanorma-site-content/index.mts
@@ -499,7 +499,7 @@ const generateCoverPage:
     currentLanguage,
     [mainTitle.type === 'title-part' ? 'title-main' : 'title-intro'],
   ) ?? {
-    hopefullyASuitableTitle: ['', '', ''],
+    mainTitle: undefined,
     titlesInOtherLanguages: [],
   };
   
@@ -576,7 +576,7 @@ const generateCoverPage:
     );
   }
 
-  if (introTitle.content === mainTitle.content) {
+  if (introTitle && introTitle.content === mainTitle.content) {
     console.warn(
       "Identical intro title and main title contents",
       introTitle.type,

--- a/packages/metanorma-site-content/schema.mts
+++ b/packages/metanorma-site-content/schema.mts
@@ -243,10 +243,7 @@ const clauseSchemaBase = new Schema({
       content: '(text | flow)*',
       group: 'block',
       toDOM(node) {
-        // FIXME: Find a way to do this without createElement
-        const el = document.createElement('pre');
-        el.innerHTML = node.attrs.formattedSource;
-        return el;
+        return ['pre', ['code', { innerHTML: node.attrs.formattedSource }]];
       },
     },
 
@@ -465,9 +462,7 @@ const clauseSchemaBase = new Schema({
       inline: true,
       group: 'flow title_flow',
       toDOM(node) {
-        const el = document.createElement('span');
-        el.innerHTML = node.attrs.mathML;
-        return el;
+        return ['span', { innerHTML: node.attrs.mathML }];
       },
     },
 


### PR DESCRIPTION
## Changes

### 1. Handle missing intro/part title in cover page generation (`index.mts`)

Documents without `title-intro`/`title-part` (like b022-e23, d036-e20, etc.) caused `getDocumentTitle` to return null, hitting a broken fallback. This made 6/8 OIML collections fail with:
```
TypeError: Cannot read properties of undefined (reading 'content')
```

### 2. Use array-based toDOM for math and source_listing nodes (`schema.mts`)

`math` and `source_listing` returned raw DOM elements via `document.createElement()`, breaking `@handlewithcare/react-prosemirror` which only supports strings and arrays in toDOM specs:
```
OutputSpec uses a DOM element: [object HTMLSpanElement]. @nytimes/react-prosemirror only supports strings and arrays in toDOM.
```

## Testing

- All 8 OIML collections build successfully with these fixes
- Site deploys to GitHub Pages correctly